### PR TITLE
mtd: enable bootcount support for ip60xx

### DIFF
--- a/package/system/mtd/src/Makefile
+++ b/package/system/mtd/src/Makefile
@@ -17,6 +17,7 @@ obj.ramips = $(obj.seama) $(obj.tpl) $(obj.wrg)
 obj.mvebu = linksys_bootcount.o
 obj.kirkwood = linksys_bootcount.o
 obj.ipq806x = linksys_bootcount.o
+obj.ipq60xx = linksys_bootcount.o
 obj.ipq40xx = linksys_bootcount.o
 
 ifdef FIS_SUPPORT


### PR DESCRIPTION
Fixes: #35

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
